### PR TITLE
Heroku connection

### DIFF
--- a/fish-finder/src/main/resources/application.properties
+++ b/fish-finder/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.datasource.password=p424296017e3cc815c5abad5c949794f3ab268bcd00fc2710b50c
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 spring.jpa.hibernate.ddl-auto=update
+#limit to 5 connections because of Heroku restrictions
 spring.datasource.hikari.maximumPoolSize=5
 spring.datasource.hikari.minimumIdle=5
 

--- a/fish-finder/src/main/resources/application.properties
+++ b/fish-finder/src/main/resources/application.properties
@@ -1,12 +1,15 @@
 server.port=8080
 spring.mvc.static-path-pattern=/**
 spring.resources.static-locations=file:client/build/
-spring.datasource.url=jdbc:postgresql://localhost:5432/fishfinder
-spring.datasource.username=fishfinder
-spring.datasource.password=fishfinder
+spring.datasource.url=jdbc:postgresql://c3gtj1dt5vh48j.cluster-czrs8kj4isg7.us-east-1.rds.amazonaws.com:5432/daiatq1aium6d6
+spring.datasource.username=ue50dporiqvf23
+spring.datasource.password=p424296017e3cc815c5abad5c949794f3ab268bcd00fc2710b50c01b2a3961cc3
 spring.datasource.driver-class-name=org.postgresql.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 spring.jpa.hibernate.ddl-auto=update
+spring.datasource.hikari.maximumPoolSize=5
+spring.datasource.hikari.minimumIdle=5
+
 
 token.secret.key=5289c03ce739f054c51371abb1a42989f113fdfc2b1c9b245769b28b277bed64
 #JWT expiration 1 hour

--- a/fish-finder/src/main/resources/application.properties
+++ b/fish-finder/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=8080
 spring.mvc.static-path-pattern=/**
-spring.resources.static-locations=file:client/build/
+spring.web.resources.static-locations=file:client/build/
 spring.datasource.url=jdbc:postgresql://c3gtj1dt5vh48j.cluster-czrs8kj4isg7.us-east-1.rds.amazonaws.com:5432/daiatq1aium6d6
 spring.datasource.username=ue50dporiqvf23
 spring.datasource.password=p424296017e3cc815c5abad5c949794f3ab268bcd00fc2710b50c01b2a3961cc3


### PR DESCRIPTION
I connected the database to the cloud using Heroku. When starting the spring-boot server, it should automatically connect with the Heroku database. If you wish to add schemas this database, add Entity classes similarly to how Brandon created User.java. You can also connect to this database via pgAdmin4 to view and edit the tables and schema.